### PR TITLE
Add new upscaler options for txt2img

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ result1 = api.txt2img(prompt="cute squirrel",
                     cfg_scale=7,
 #                      sampler_index='DDIM',
 #                      steps=30,
+#                      enable_hr=True,
+#                      hr_scale=2,
+#                      hr_upscaler='Latent',
+#                      hr_second_pass_steps=20,
+#                      hr_resize_x=1536,
+#                      hr_resize_y=1024,
+#                      denoising_strength=0.4,
+
                     )
 # images contains the returned images (PIL images)
 result1.images

--- a/webuiapi/webuiapi.py
+++ b/webuiapi/webuiapi.py
@@ -74,6 +74,11 @@ class WebUIApi:
 
     def txt2img(self,
                 enable_hr=False,
+                hr_scale=2,
+                hr_upscaler='latent',
+                hr_second_pass_steps=0,
+                hr_resize_x=0,
+                hr_resize_y=0,
                 denoising_strength=0.0,
                 firstphase_width=0,
                 firstphase_height=0,
@@ -113,9 +118,13 @@ class WebUIApi:
             steps = self.default_steps
         if script_args is None:
             script_args = []
-
         payload = {
             "enable_hr": enable_hr,
+            "hr_scale" : hr_scale,
+            "hr_upscaler" : hr_upscaler,
+            "hr_second_pass_steps" : hr_second_pass_steps,
+            "hr_resize_x": hr_resize_x,
+            "hr_resize_y": hr_resize_y,
             "denoising_strength": denoising_strength,
             "firstphase_width": firstphase_width,
             "firstphase_height": firstphase_height,


### PR DESCRIPTION
I noticed that the txt2img function was missing the new options around upscaling. I added them and validated locally that it is working against the latest version of automatic1111.

Also updated the readme with commented out options for the txt2img piece.

Hope this makes sense :p 