### PR TITLE
bugfix: when async api fail, raise the right error message

### DIFF
--- a/webuiapi/webuiapi.py
+++ b/webuiapi/webuiapi.py
@@ -201,7 +201,7 @@ class WebUIApi:
 
     async def _to_api_result_async(self, response):
         if response.status != 200:
-            raise RuntimeError(response.status, await response.text)
+            raise RuntimeError(response.status, await response.text())
 
         r = await response.json()
         images = []


### PR DESCRIPTION
In async mode, use "await response.text()" instead of await "await response.text"