### PR TITLE
Fixed the `x/y/z plot` script args error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,14 @@ XYZPlotAvailableImg2ImgScripts = [
 
 # Example call
 XAxisType = "Steps"
-XAxisValues = "20,30" 
+XAxisValues = "20,30"
+XAxisValuesDropdown = ""
 YAxisType = "Sampler"
 YAxisValues = "Euler a, LMS"
+YAxisValuesDropdown = ""
 ZAxisType = "Nothing"
 ZAxisValues = ""
+ZAxisValuesDropdown = ""
 drawLegend = "True"
 includeLoneImages = "False"
 includeSubGrids = "False"
@@ -245,10 +248,13 @@ result = api.txt2img(
                     script_args=[
                         XYZPlotAvailableTxt2ImgScripts.index(XAxisType),
                         XAxisValues,
+                        XAxisValuesDropdown,
                         XYZPlotAvailableTxt2ImgScripts.index(YAxisType),
                         YAxisValues,
+                        YAxisValuesDropdown,
                         XYZPlotAvailableTxt2ImgScripts.index(ZAxisType),
                         ZAxisValues,
+                        ZAxisValuesDropdown,
                         drawLegend,
                         includeLoneImages,
                         includeSubGrids,


### PR DESCRIPTION
The `x/y/z plot` script have a new args format, so the example in `README.md` is out of date.  This change has led to the emergence of an error message:
```
list indices must be integers or slices, not str
```

For further information, please consult the following link: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11736
