### PR TITLE
Bugfix __init__.py

### DIFF
--- a/webuiapi/__init__.py
+++ b/webuiapi/__init__.py
@@ -15,7 +15,7 @@ from .webuiapi import (
     Roop,
     ReActor,
     ADetailer,    
-    Roop
+    Roop,
     SegmentAnythingInterface,
     SegmentAnythingSamResult,
     SegmentAnythingDilationResult,


### PR DESCRIPTION
There is a bug that makes the api unusable. This fixes it. There was missing a coma in the __init__ import