### PR TITLE
Fix ADetailer Disabling

### DIFF
--- a/webuiapi/webuiapi.py
+++ b/webuiapi/webuiapi.py
@@ -94,7 +94,16 @@ class ControlNetUnit:
                 "ControlNetUnit guessmode is deprecated. Please use control_mode instead."
             )
             control_mode = guessmode
-        self.control_mode = control_mode
+
+        if control_mode == 0:
+            self.control_mode = 'Balanced',
+        elif control_mode == 1:
+            self.control_mode = 'My prompt is more important'
+        elif control_mode == 2:
+            self.control_mode = 'ControlNet is more important'
+        else:
+            self.control_mode = control_mode
+
         self.pixel_perfect = pixel_perfect
         self.hr_option = hr_option
 

--- a/webuiapi/webuiapi.py
+++ b/webuiapi/webuiapi.py
@@ -582,6 +582,10 @@ class WebUIApi:
             payload["alwayson_scripts"]["ADetailer"] = {
                 "args": ads
             }
+        else:
+            payload["alwayson_scripts"]["ADetailer"] = {
+                "args": [False]
+            }
 
         if roop :
             payload["alwayson_scripts"]["roop"] = {

--- a/webuiapi/webuiapi.py
+++ b/webuiapi/webuiapi.py
@@ -371,6 +371,7 @@ def raw_b64_img(image: Image) -> str:
 
 class WebUIApi:
     has_controlnet = False
+    has_adetailer = False
 
     def __init__(
         self,
@@ -398,7 +399,12 @@ class WebUIApi:
         if username and password:
             self.set_auth(username, password)
         else:
-            self.check_controlnet()
+            self.check_extensions()
+
+
+    def check_extensions(self):
+        self.check_controlnet()
+        self.check_adetailer()
 
     def check_controlnet(self):
         try:
@@ -407,9 +413,16 @@ class WebUIApi:
         except:
             pass
 
+    def check_adetailer(self):
+        try:
+            scripts = self.get_scripts()
+            self.has_adetailer = "adetailer" in scripts["txt2img"]
+        except:
+            pass
+
     def set_auth(self, username, password):
         self.session.auth = (username, password)
-        self.check_controlnet()
+        self.check_extensions()
 
     def _to_api_result(self, response):
         if response.status_code != 200:
@@ -582,7 +595,7 @@ class WebUIApi:
             payload["alwayson_scripts"]["ADetailer"] = {
                 "args": ads
             }
-        else:
+        elif self.has_adetailer:
             payload["alwayson_scripts"]["ADetailer"] = {
                 "args": [False]
             }
@@ -750,6 +763,11 @@ class WebUIApi:
             payload["alwayson_scripts"]["ADetailer"] = {
                 "args": ads
             }
+        elif self.has_adetailer:
+            payload["alwayson_scripts"]["ADetailer"] = {
+                "args": [False]
+            }
+
         if roop :
             payload["alwayson_scripts"]["roop"] = {
                 "args": roop.to_dict()


### PR DESCRIPTION
## Expected Behavior

```python
result1 = api.img2img(
    ...
    adetailer=[webuiapi.ADetailer()],
)

result2 = api.img2img(
    ...
    adetailer=[],
)
```

ADetailer will be applied **only** for `result1`.


## Current Behavior

ADetailer will be applied for **both** `result1` and `result2`. Actually it will be applied every time if it was used once.


## Solution

Using `False` as a first arg if `ADetailer` instances are not passed. 
Source: [ADetailer API Wiki](https://github.com/Bing-su/adetailer/wiki/API#:~:text=The%20first%20true%20(ad_enable)%20is%20not%20required.%20In%20this%20case%2C%20ad_enable%20will%20be%20true.)